### PR TITLE
Fix firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
       match /users/{userId} {
         allow read: if true;
         allow create: if request.auth != null && request.auth.uid == userId;
-        allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
+        allow update: if resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
       } match /invitations/{invId} {
         allow read: if true;
         allow create: if request.auth != null && request.auth.uid == request.resource.data.to;

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,7 +4,7 @@ service cloud.firestore {
     match /{document=**} {
       match /users/{userId} {
         allow read: if true;
-        allow write: if request.auth != null && request.auth.uid == userId;
+        allow create: if request.auth != null && request.auth.uid == userId;
         allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
       } match /invitations/{invId} {
         allow read: if true;

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
       match /users/{userId} {
         allow read: if true;
         allow write: if request.auth != null && request.auth.uid == userId && resource.data.invitation == request.resource.data.invitation && resource.data.invitationKey == request.resource.data.invitationKey;
-        allow create: if request.auth != null && request.auth.uid == userId;
+        allow create: if request.auth != null && request.auth.uid == userId && request.resource.data.invitation == 3;
         allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
       } match /invitations/{invId} {
         allow read: if true;

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,7 @@ service cloud.firestore {
       match /users/{userId} {
         allow read: if true;
         allow write: if request.auth != null && request.auth.uid == userId && resource.data.invitation == request.resource.data.invitation && resource.data.invitationKey == request.resource.data.invitationKey;
+        allow create: if request.auth != null && request.auth.uid == userId;
         allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
       } match /invitations/{invId} {
         allow read: if true;

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,8 +4,8 @@ service cloud.firestore {
     match /{document=**} {
       match /users/{userId} {
         allow read: if true;
-        allow create: if request.auth != null && request.auth.uid == userId && request.resource.data.invitation == 3;
-        allow update: if resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
+        allow write: if request.auth != null && request.auth.uid == userId && resource.data.invitation == request.resource.data.invitation && resource.data.invitationKey == request.resource.data.invitationKey;
+        allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
       } match /invitations/{invId} {
         allow read: if true;
         allow create: if request.auth != null && request.auth.uid == request.resource.data.to;

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,7 +4,7 @@ service cloud.firestore {
     match /{document=**} {
       match /users/{userId} {
         allow read: if true;
-        allow create: if request.auth != null && request.auth.uid == userId;
+        allow create: if request.auth != null && request.auth.uid == userId && request.resource.data.invitation == 3;
         allow update: if resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
       } match /invitations/{invId} {
         allow read: if true;


### PR DESCRIPTION
Firestoreのルールにおいて、`users`に対する`write`条件が操作されるべきではないフィールドを弾いていなかったため修正しました。
(Firestoreのルールは書いたことなかったけど多分動くはず...)