### PR TITLE
Fix Security Rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,15 +2,14 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /users/{userId} {
-      allow read: if true;
+      allow read;
       allow write: if request.auth != null && request.auth.uid == userId && resource.data.invitation == request.resource.data.invitation && resource.data.invitationKey == request.resource.data.invitationKey;
       allow create: if request.auth != null && request.auth.uid == userId && request.resource.data.invitation == 3;
       allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
     }
     match /invitations/{invId} {
-      allow read: if true;
+      allow read;
       allow create: if request.auth != null && request.auth.uid == request.resource.data.to;
-      allow update: if false;
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,17 +1,16 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      match /users/{userId} {
-        allow read: if true;
-        allow write: if request.auth != null && request.auth.uid == userId && resource.data.invitation == request.resource.data.invitation && resource.data.invitationKey == request.resource.data.invitationKey;
-        allow create: if request.auth != null && request.auth.uid == userId && request.resource.data.invitation == 3;
-        allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
-      } match /invitations/{invId} {
-        allow read: if true;
-        allow create: if request.auth != null && request.auth.uid == request.resource.data.to;
-        allow update: if false;
-      }
+    match /users/{userId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == userId && resource.data.invitation == request.resource.data.invitation && resource.data.invitationKey == request.resource.data.invitationKey;
+      allow create: if request.auth != null && request.auth.uid == userId && request.resource.data.invitation == 3;
+      allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
+    }
+    match /invitations/{invId} {
+      allow read: if true;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.to;
+      allow update: if false;
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,13 +3,30 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /users/{userId} {
       allow read;
-      allow write: if request.auth != null && request.auth.uid == userId && resource.data.invitation == request.resource.data.invitation && resource.data.invitationKey == request.resource.data.invitationKey;
-      allow create: if request.auth != null && request.auth.uid == userId && request.resource.data.invitation == 3;
-      allow update: if resource.data.name == request.resource.data.name && resource.data.image == request.resource.data.image && resource.data.invitationKey == request.resource.data.invitationKey  && resource.data.timestamp == request.resource.data.timestamp  && resource.data.invitation - 1 == request.resource.data.invitation;
+      allow create: if request.auth != null
+        && request.auth.uid == userId
+        && request.resource.data.keys().toSet() == ['name', 'image', 'invitation', 'invitationKey', 'timestamp'].toSet()
+        && request.resource.data.name is string
+        && request.resource.data.image is string
+        && request.resource.data.invitation is int
+        && request.resource.data.invitationKey is string
+        && request resource.data.timestamp is timestamp
+        && request.resource.data.invitation == 3
+        && request.resource.data.timestamp == request.time;
+      allow update: if request.auth != null
+        && request.auth.uid == userId
+        && request.resource.data.diff(resource.data).affectedKeys() == ['invitation'].toSet()
+        && request.resource.data.invitation == resource.data.invitation - 1;
     }
     match /invitations/{invId} {
       allow read;
-      allow create: if request.auth != null && request.auth.uid == request.resource.data.to;
+      allow create: if request.auth != null
+        && request.resource.data.keys().toSet() == ['from', 'to', 'timestamp'].toSet()
+        && request.resource.data.from is string
+        && request.resource.data.to is string
+        && request resource.data.timestamp is timestamp
+        && request.resource.data.to == request.auth.uid
+        && request.resource.data.timestamp == request.time;
     }
   }
 }


### PR DESCRIPTION
 ・match /{document=**} は任意の階層の階層のコレクションに適用されます。元のルールでは /hoges/{hoge}/users/{uid}みたいなコレクションに対する書き込みが許可されてしまうので修正しました。
・if trueは冗長なので消し、if falseは書く必要がないので消しました。
・allow writeは必要なさそうなので消しました。
・コードを見ながら、書き込まれるデータの型検査を追加しました。もしかしたら間違っているかもしれないので動作確認をお願いします。
